### PR TITLE
Remove Expo from the CLI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,18 +97,6 @@ jobs:
                   command: |
                       bin/blui new react-native --name=reactnativetest --lint --prettier --language=typescript
 
-    build_ionic:
-        working_directory: ~/@brightlayer-ui-cli
-        docker:
-            - image: cimg/node:14.19.0-browsers
-        steps:
-            - checkout
-            - attach_workspace:
-                  at: .
-            - run:
-                  name: Build Ionic Project
-                  command: |
-                      bin/blui new ionic --name=ionictest --lint --prettier --template=blank
     publish:
         docker:
             - image: cimg/node:14.19.0-browsers
@@ -164,18 +152,9 @@ workflows:
             #       only:
             #          - master
             #          - dev
-            # - build_ionic:
-            #    requires:
-            #      - build_cli
-            #    filters:
-            #      branches:
-            #        only:
-            #          - master
-            #          - dev
             - publish:
                   requires:
                       - build_angular
-                      #  - build_ionic
                       - build_react
                   #  - build_react_native
                   filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,199 +3,197 @@ orbs:
     codecov: codecov/codecov@1.1.3
     gh: circleci/github-cli@1.0.3
 jobs:
-  build_cli:
-    working_directory: ~/@brightlayer-ui-cli
-    docker:
-      - image: cimg/node:14.19.0-browsers
-    resource_class: large
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v2-dependencies-{{ checksum "yarn.lock" }}
-      - run:
-          name: Install Dependencies
-          command: |
-            yarn install --frozen-lockfile
-      - save_cache:
-          name: Save Cache
-          paths:
-            - node_modules
-          key: v2-dependencies-{{ checksum "yarn.lock" }}
-      - run:
-          name: Prettier Check
-          command: |
-            yarn prettier:check
-      - run:
-          name: Lint
-          command: |
-            yarn lint
-      - run:
-          name: Unit Tests
-          command: |
-            yarn test --coverage --watchAll=false
-      - run:
-          name: Build
-          command: |
-            yarn build
-      # Save the dist folder for use in future jobs.
-      - persist_to_workspace:
-          root: .
-          paths:
-            - node_modules
-            - build
-            - bin
-            - coverage
-  coverage_report:
+    build_cli:
+        working_directory: ~/@brightlayer-ui-cli
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        resource_class: large
+        steps:
+            - checkout
+            - restore_cache:
+                  keys:
+                      - v2-dependencies-{{ checksum "yarn.lock" }}
+            - run:
+                  name: Install Dependencies
+                  command: |
+                      yarn install --frozen-lockfile
+            - save_cache:
+                  name: Save Cache
+                  paths:
+                      - node_modules
+                  key: v2-dependencies-{{ checksum "yarn.lock" }}
+            - run:
+                  name: Prettier Check
+                  command: |
+                      yarn prettier:check
+            - run:
+                  name: Lint
+                  command: |
+                      yarn lint
+            - run:
+                  name: Unit Tests
+                  command: |
+                      yarn test --coverage --watchAll=false
+            - run:
+                  name: Build
+                  command: |
+                      yarn build
+            # Save the dist folder for use in future jobs.
+            - persist_to_workspace:
+                  root: .
+                  paths:
+                      - node_modules
+                      - build
+                      - bin
+                      - coverage
+    coverage_report:
         working_directory: ~/@brightlayer-ui-cli
         docker:
             - image: cimg/node:14.19.0-browsers
         steps:
             - checkout
             - attach_workspace:
-                at: .
+                  at: .
             - codecov/upload:
-                file: './coverage/clover.xml'
-                token: c928f23e-512b-48eb-aacf-f57c2fc9516f
+                  file: './coverage/clover.xml'
+                  token: c928f23e-512b-48eb-aacf-f57c2fc9516f
 
-  build_angular:
-      working_directory: ~/@brightlayer-ui-cli
-      docker:
-          - image: cimg/node:14.19.0-browsers
-      steps:
-        - checkout
-        - attach_workspace:
-            at: .
-        - run:
-            name: Build Angular Project
-            command: |
-              bin/blui new angular --name=angulartest --lint --prettier --template=blank
+    build_angular:
+        working_directory: ~/@brightlayer-ui-cli
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - run:
+                  name: Build Angular Project
+                  command: |
+                      bin/blui new angular --name=angulartest --lint --prettier --template=blank
 
-  build_react:
-    working_directory: ~/@brightlayer-ui-cli
-    docker:
-        - image: cimg/node:14.19.0-browsers
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build React Project
-          command: |
-            bin/blui new react --name=reacttest --lint --prettier --language=typescript --template=blank
+    build_react:
+        working_directory: ~/@brightlayer-ui-cli
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - run:
+                  name: Build React Project
+                  command: |
+                      bin/blui new react --name=reacttest --lint --prettier --language=typescript --template=blank
 
+    build_react_native:
+        working_directory: ~/@brightlayer-ui-cli
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - run:
+                  name: Build React Native Project
+                  command: |
+                      bin/blui new react-native --name=reactnativetest --lint --prettier --language=typescript
 
-  build_react_native:
-    working_directory: ~/@brightlayer-ui-cli
-    docker:
-        - image: cimg/node:14.19.0-browsers
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build React Native Project
-          # TODO: Using Expo for the test now because react-native link has stopped working on CircleCI
-          command: |
-            bin/blui new react-native --name=reactnativetest --cli=expo --lint --prettier --language=typescript
-            
-  build_ionic:
-    working_directory: ~/@brightlayer-ui-cli
-    docker:
-        - image: cimg/node:14.19.0-browsers
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Build Ionic Project
-          command: |
-            bin/blui new ionic --name=ionictest --lint --prettier --template=blank
-  publish:
-    docker:
-      - image: cimg/node:14.19.0-browsers
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Authenticate with registry
-          command:  |
-            echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
-            echo "//registry.yarnpkg.com/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run:
-          name: Publish @brightlayer-ui/cli
-          command:  |
-            yarn publish:package -b $CIRCLE_BRANCH
-  tag:
-    docker:
-      - image: cimg/node:14.19.0-browsers
-    steps:
-      - checkout
-      - gh/setup
-      - run:
-          name: Tag @brightlayer-ui/cli
-          command: |
-            yarn tag:package -b $CIRCLE_BRANCH -s -blui-cli
+    build_ionic:
+        working_directory: ~/@brightlayer-ui-cli
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - run:
+                  name: Build Ionic Project
+                  command: |
+                      bin/blui new ionic --name=ionictest --lint --prettier --template=blank
+    publish:
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        steps:
+            - checkout
+            - attach_workspace:
+                  at: .
+            - run:
+                  name: Authenticate with registry
+                  command: |
+                      echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+                      echo "//registry.yarnpkg.com/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+            - run:
+                  name: Publish @brightlayer-ui/cli
+                  command: |
+                      yarn publish:package -b $CIRCLE_BRANCH
+    tag:
+        docker:
+            - image: cimg/node:14.19.0-browsers
+        steps:
+            - checkout
+            - gh/setup
+            - run:
+                  name: Tag @brightlayer-ui/cli
+                  command: |
+                      yarn tag:package -b $CIRCLE_BRANCH -s -blui-cli
 workflows:
-  version: 2
-  blui_cli:
-    jobs:
-      - build_cli
-      - build_angular:
-          requires:
+    version: 2
+    blui_cli:
+        jobs:
             - build_cli
-          filters:
-            branches:
-              only:
-                - master
-                - dev
-      - build_react:
-          requires:
-            - build_cli
-          filters:
-            branches:
-              only:
-                - master
-                - dev
-      #- build_react_native:
-      #    requires:
-      #      - build_cli
-      #    filters:
-      #      branches:
-      #       only:
-      #          - master
-      #          - dev
-      # - build_ionic:
-      #    requires:
-      #      - build_cli
-      #    filters:
-      #      branches:
-      #        only:
-      #          - master
-      #          - dev
-      - publish:
-          requires:
-            - build_angular
-          #  - build_ionic
-            - build_react
-          #  - build_react_native
-          filters:
-            branches:
-              only:
-                - master
-                - dev
-      - tag:
-          requires:
-            - publish
-          filters:
-            branches:
-              only:
-                - master
-      - coverage_report:
-                   requires:
-                        - build_cli
-                   filters:
-                        branches:
-                            only:
-                                - master
+            - build_angular:
+                  requires:
+                      - build_cli
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - dev
+            - build_react:
+                  requires:
+                      - build_cli
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - dev
+            #- build_react_native:
+            #    requires:
+            #      - build_cli
+            #    filters:
+            #      branches:
+            #       only:
+            #          - master
+            #          - dev
+            # - build_ionic:
+            #    requires:
+            #      - build_cli
+            #    filters:
+            #      branches:
+            #        only:
+            #          - master
+            #          - dev
+            - publish:
+                  requires:
+                      - build_angular
+                      #  - build_ionic
+                      - build_react
+                  #  - build_react_native
+                  filters:
+                      branches:
+                          only:
+                              - master
+                              - dev
+            - tag:
+                  requires:
+                      - publish
+                  filters:
+                      branches:
+                          only:
+                              - master
+            - coverage_report:
+                  requires:
+                      - build_cli
+                  filters:
+                      branches:
+                          only:
+                              - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,16 @@
 # Changelog
 
-## v1.9.0 (unreleased)
+## v2.0.0 (unreleased)
 
 ### Changed
 
-- Update angular projects to use angular 13.
-- Updated bundle size budgets when building angular projects.
+-   Update angular projects to use angular 13.
+-   Updated bundle size budgets when building angular projects.
 
 ### Removed
 
--   Removed ability to generate new Ionic projects. 
+-   Removed ability to generate new Ionic projects. (#115)[https://github.com/brightlayer-ui/brightlayer-ui-cli/issues/115]
+-   Removed ability to generate new React Native projects using Expo. (#114)[https://github.com/brightlayer-ui/brightlayer-ui-cli/issues/114]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ In order to use this utility you must have the following installed:
 Additional requirements for creating React Native projects:
 
 -   [Cocoapods](https://cocoapods.org/) 1.8+ (for ios)
--   [Expo CLI](https://docs.expo.io/versions/latest/workflow/expo-cli/) - only if you want to scaffold your project with Expo
 
 ## Usage
 
@@ -49,15 +48,14 @@ $ npm install -g @brightlayer-ui/cli
 
 The following table list out some options for the `blui new` command. All these options can be configured
 
-| Option                                                         | Description                                                                                                                                                                                                                           |
-| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| <code>--framework=<angular\|react\|react-native></code> | The framework in which the project will be generated.                                                                                                                                                                                 |
-| `--name=<name>`                                                | Project name                                                                                                                                                                                                                          |
-| <code>--cli=<rnc\|expo></code>                                 | (React Native projects only) which CLI to use to generate the project. We support `rnc` ([React-Native Community CLI](https://github.com/react-native-community/cli)) or `expo` ([Expo CLI](https://docs.expo.io/workflow/expo-cli/)) |
-| <code>--template=<blank\|routing\|authentication></code>       | Template to use to start the project                                                                                                                                                                                                  |
-| `--lint`                                                       | (TypeScript projects only) Install and configure [Brightlayer UI lint package](https://www.npmjs.com/package/@brightlayer-ui/eslint-config) (omit or `--lint=false` to disable)                                                       |
-| `--prettier`                                                   | Install and configure [Brightlayer UI prettier package](https://www.npmjs.com/package/@brightlayer-ui/prettier-config) (omit or `--prettier=false` to disable)                                                                        |
-| <code>--language=<typescript\|javascript></code>               | (React & React Native Only) The language in which the project will be generated                                                                                                                                                       |
+| Option                                                   | Description                                                                                                                                                                     |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <code>--framework=<angular\|react\|react-native></code>  | The framework in which the project will be generated.                                                                                                                           |
+| `--name=<name>`                                          | Project name                                                                                                                                                                    |
+| <code>--template=<blank\|routing\|authentication></code> | Template to use to start the project                                                                                                                                            |
+| `--lint`                                                 | (TypeScript projects only) Install and configure [Brightlayer UI lint package](https://www.npmjs.com/package/@brightlayer-ui/eslint-config) (omit or `--lint=false` to disable) |
+| `--prettier`                                             | Install and configure [Brightlayer UI prettier package](https://www.npmjs.com/package/@brightlayer-ui/prettier-config) (omit or `--prettier=false` to disable)                  |
+| <code>--language=<typescript\|javascript></code>         | (React & React Native Only) The language in which the project will be generated                                                                                                 |
 
 ## Detailed Usage
 
@@ -67,20 +65,31 @@ To start a new project with Brightlayer UI integration follow the steps below. W
 2. Choose your desired framework from the list
     - Alternatively, you can pre-select a framework by running `npx -p @brightlayer-ui/cli blui new <framework>`
 3. You will be prompted to enter a name for your project. Make sure the name you select meets the requirements of the CLI for your chosen framework.
-4. For React Native projects, you'll be asked which CLI to use to scaffold your project. You can choose between the React Native Community CLI (recommended) or Expo (better for smaller demo or proof-of-concept projects).
-    > **Note for Expo projects:** If you are creating an Expo project and you are behind a proxy, you will need to ensure that you have environment variables set for `HTTP_PROXY` and `HTTPS_PROXY`. Depending on your firewall settings, you may also need to temporarily add an environment variable for `NODE_TLS_REJECT_UNAUTHORIZED=0` (remove this promptly after your project is created).
-5. You will be prompted to choose a template from our list of [angular](https://github.com/brightlayer-ui/angular-cli-templates/tree/master), [react](https://github.com/brightlayer-ui/react-cli-templates/tree/master), or [react native](https://github.com/brightlayer-ui/react-native-cli-templates/tree/master) templates (RNC CLI only) to scaffold your project:
+4. You will be prompted to choose a template from our list of [angular](https://github.com/brightlayer-ui/angular-cli-templates/tree/master), [react](https://github.com/brightlayer-ui/react-cli-templates/tree/master), or [react native](https://github.com/brightlayer-ui/react-native-cli-templates/tree/master) templates to scaffold your project:
     - Blank: a basic application with a simple placeholder homepage
     - Routing: integrates React Router with a simple drawer navigation and several placeholder routes
     - Authentication: integrates the [react](https://www.npmjs.com/package/@brightlayer-ui/react-auth-workflow), [angular](https://www.npmjs.com/package/@brightlayer-ui/angular-auth-workflow), or [react native](https://www.npmjs.com/package/@brightlayer-ui/react-native-auth-workflow) auth-workflow login and registration screens plus everything from the routing template
-6. If you are creating a React or React Native project, you will be prompted to choose JavaScript or Typescript for your project language.
-7. You will be asked if you want to use the Brightlayer UI Linting configuration and code formatting packages (recommended).
-8. The CLI will install all of the necessary dependencies for your project and integrate the Brightlayer UI components, themes, and fonts. When complete, the CLI should present you instructions for running your project.
-    > **Note for React Native projects:** If you are using the React Native Community CLI for your react native project, there are additional steps you must run for your project to run on iOS. Follow the on-screen instructions for running `pod install` to link the react-native-vector-icons package. If you are using xCode 11+, you will also need to update the Build Phases in xCode to avoid duplicated resources errors (refer to [this issue](https://github.com/oblador/react-native-vector-icons/issues/1074)).
+5. If you are creating a React or React Native project, you will be prompted to choose JavaScript or Typescript for your project language.
+6. You will be asked if you want to use the Brightlayer UI Linting configuration and code formatting packages (recommended).
+7. The CLI will install all of the necessary dependencies for your project and integrate the Brightlayer UI components, themes, and fonts. When complete, the CLI should present you instructions for running your project.
+    > **Note for React Native projects:** There are additional steps you must run for your project to run on iOS. Follow the on-screen instructions for running `pod install` to link the react-native-vector-icons package. If you are using xCode 11+, you will also need to update the Build Phases in xCode to avoid duplicated resources errors (refer to [this issue](https://github.com/oblador/react-native-vector-icons/issues/1074)).
 
 ### Testing / Debugging Templates (For Maintainers)
 
 You should always use the latest version of the templates when starting a new project to make sure you have the latest features and bug fixes.
+
+#### Testing CLI itself
+
+Once changes are made, you need to build the binary file first, and link it.
+
+```
+yarn build
+yarn link
+```
+
+Now you may use it as if it is installed locally, such as running `blui new` from another directory.
+
+#### Testing Templates
 
 If you are a library maintainer and you need to test out different versions of the templates during development, there are several ways to do this:
 

--- a/src/constants/dependencies.ts
+++ b/src/constants/dependencies.ts
@@ -1,20 +1,3 @@
-export const DEPENDENCIES = {
-    expo: [
-        '@brightlayer-ui/react-native-themes@^6.0.0',
-        '@brightlayer-ui/colors@^3.0.1',
-        '@brightlayer-ui/react-native-components@^6.0.0',
-        '@brightlayer-ui/react-native-vector-icons@^1.0.0',
-        'react-native-paper@^4.2.0',
-        '@brightlayer-ui/icons-svg@^1.0.0',
-        'react-native-vector-icons@^8.0.0',
-        'react-native-svg@^12.1.0',
-        'react-native-svg-transformer@^0.14.3',
-        'react-native-safe-area-context@^3.1.9',
-    ],
-};
-export const DEV_DEPENDENCIES = {
-    expo: ['jest', 'react-test-renderer', '@types/react-native-vector-icons'],
-};
 const BASE_LINT_DEPENDENCIES = [
     '@brightlayer-ui/eslint-config@^2.0.2',
     'eslint@^7.11.0',

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -24,12 +24,6 @@ export const QUESTIONS = {
         type: 'radio',
         choices: ['TypeScript', 'JavaScript'],
     },
-    cli: {
-        optionName: 'cli',
-        question: 'Which CLI should we use?',
-        type: 'radio',
-        choices: ['React Native Community (recommended)', 'Expo'],
-    },
     framework: {
         optionName: 'framework',
         question: 'Project Framework:',

--- a/src/extensions/file-extensions.ts
+++ b/src/extensions/file-extensions.ts
@@ -3,14 +3,12 @@
  * and creating config files.
  */
 import { GluegunToolbox, filesystem } from 'gluegun';
-import { NPM7_PREFIX } from '../constants';
 
 type InstallProps = {
     folder: string;
     dependencies: string[];
     dev?: boolean;
     description: string;
-    expo?: boolean;
 };
 type LintConfigProps = {
     folder: string;
@@ -21,13 +19,11 @@ module.exports = (toolbox: GluegunToolbox): void => {
     const { system, print } = toolbox;
 
     const installDependencies = async (props: InstallProps): Promise<void> => {
-        const { folder, dependencies, dev = false, description, expo = false } = props;
+        const { folder, dependencies, dev = false, description } = props;
         if (!dependencies || dependencies.length < 1) return;
 
         const isYarn = filesystem.exists(`./${folder}/yarn.lock`);
-        const installCommand = expo
-            ? `cd ${folder} && ${NPM7_PREFIX} && npx -p expo-cli expo install`
-            : dev
+        const installCommand = dev
             ? `cd ${folder} && ${isYarn ? 'yarn add --dev' : 'npm install --save-dev'}`
             : `cd ${folder} && ${isYarn ? 'yarn add' : 'npm install --save'}`;
 

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -6,8 +6,6 @@ import { GluegunToolbox } from 'gluegun';
 import { NPM7_PREFIX, QUESTIONS } from '../constants';
 import {
     assignJsTs,
-    stringToLowerCaseNoSpace,
-    Cli,
     AngularProps,
     ReactProps,
     ReactNativeProps,
@@ -101,16 +99,9 @@ module.exports = (toolbox: GluegunToolbox): void => {
         // Choose a name
         const [name]: [string] = await parse([QUESTIONS.name]);
 
-        // Choose a CLI
-        let [cliTemp]: [string] = await parse([QUESTIONS.cli]);
-        cliTemp = stringToLowerCaseNoSpace(cliTemp);
-        const cli: Cli = cliTemp === 'expo' ? 'expo' : 'rnc';
-
         // Choose a template
         let template = '';
-        if (cli !== 'expo') {
-            [template] = await parse([QUESTIONS.template]);
-        }
+        [template] = await parse([QUESTIONS.template]);
 
         // Choose a language
         const [languageTemp]: [string] = await parse([QUESTIONS.language]);
@@ -125,16 +116,9 @@ module.exports = (toolbox: GluegunToolbox): void => {
         const [prettier] = await parse([QUESTIONS.prettier]);
 
         // Create the basic project
-        let command: string;
-        if (cli === 'expo') {
-            command = `${NPM7_PREFIX} && npx -p expo-cli expo init --name=${name} --template=${
-                isTs ? 'expo-template-blank-typescript' : 'blank'
-            } "${name}"`;
-        } else {
-            command = `${NPM7_PREFIX} && npx -p react-native@0.64.1 react-native init ${name} ${
-                isTs ? '--template react-native-template-typescript@6.6.4' : '--template react-native@0.64.1'
-            }`;
-        }
+        const command = `${NPM7_PREFIX} && npx -p react-native@0.64.1 react-native init ${name} ${
+            isTs ? '--template react-native-template-typescript@6.6.4' : '--template react-native@0.64.1'
+        }`;
 
         const spinner = print.spin('Creating a new React Native project (this may take a few minutes)...');
         const timer = system.startTimer();
@@ -144,7 +128,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         print.info(output);
         print.success(`Created skeleton React Native project in ${timer() / 1000} seconds`);
 
-        return { name, language, lint, prettier, cli, template };
+        return { name, language, lint, prettier, template };
     };
 
     toolbox.createProject = {

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,5 +1,4 @@
 export type Language = 'ts' | 'js';
-export type Cli = 'expo' | 'rnc';
 
 export type Template = 'Blank' | 'Basic Routing' | 'Authentication';
 
@@ -20,7 +19,6 @@ export type ReactNativeProps = {
     language: Language;
     lint: boolean;
     prettier: boolean;
-    cli: Cli;
     template: string;
 };
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes #114, BLUI-2066

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Drop support for EXPO
- Updated Read Me

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:

Whether you are running `blui new` or `blui new react-native --cli=expo --name=asdf --language=js --lint --prettier`, they all work. It does not ask you which CLI you want to use anymore and spins up a healthy React Native project by default.

![image](https://user-images.githubusercontent.com/8997218/159978287-f8528434-7b51-4204-bfb0-5cbd2221d4f5.png)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- follow the instruction in the readme 
-  Try testing commands like `blui new react-native --cli=expo`. You will see that the command prompt reacts as if there's no `cli` flag at all.
