### PR TITLE
fix: issue#132: does squash iOS instructions into 2 lines and adds missing instructions for the Andrioid

### DIFF
--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -507,13 +507,12 @@ module.exports = (toolbox: GluegunToolbox): void => {
         printSuccess(name);
         printInstructions([
             `iOS:`,
-            `• cd ${name}/ios`,
-            `• pod install`,
-            `• cd ..`,
+            `• cd ${name}/ios && pod install && cd ..`,
             `• ${isYarn ? 'yarn' : 'npm run'} ios`,
             ``,
             `Android:`,
             `• Have an Android emulator running`,
+            `• cd ${name}`,
             `• ${isYarn ? 'yarn' : 'npm run'} android`,
         ]);
         print.warning(


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes [#132](https://github.com/brightlayer-ui/brightlayer-ui-cli/issues/132).

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- squash iOS instructions into 2lines 
- add missing instruction for Android's path
