### PR TITLE
Feature/3642 remove references of js templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v2.3.0 (Unreleased)
+
+### Removed
+
+-   Removed language selection question from React and React native.
+
+### Changed
+
+-   React and React native blui cli generated project to use Typescript only.
+
 ## v2.2.0 (November 29, 2022)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following table list out some options for the `blui new` command. All these 
 | <code>--template=<blank\|routing\|authentication></code> | Template to use to start the project                                                                                                                                            |
 | `--lint`                                                 | (TypeScript projects only) Install and configure [Brightlayer UI lint package](https://www.npmjs.com/package/@brightlayer-ui/eslint-config) (omit or `--lint=false` to disable) |
 | `--prettier`                                             | Install and configure [Brightlayer UI prettier package](https://www.npmjs.com/package/@brightlayer-ui/prettier-config) (omit or `--prettier=false` to disable)                  |
-| <code>--language=<typescript\|javascript></code>         | (React & React Native Only) The language in which the project will be generated                                                                                                 |
+| <code>--language=<typescript></code>                     | (React & React Native Only) The language in which the project will be generated                                                                                                 |
 
 ## Detailed Usage
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -2,30 +2,24 @@
 
 ### Manual Steps
 
-#### Angular 
-1. User can create a new project from the blank template.
-2. User can create a new project from the routing template.
-3. User can create a new project from the auth-workflow template. 
+#### Angular
 
-#### React (Typescript)
 1. User can create a new project from the blank template.
 2. User can create a new project from the routing template.
 3. User can create a new project from the auth-workflow template.
 
-#### React (Javascript)
+#### React (Typescript)
+
 1. User can create a new project from the blank template.
 2. User can create a new project from the routing template.
 3. User can create a new project from the auth-workflow template.
 
 #### React Native (Typescript)
-1. User can create a new project from the blank template.
-2. User can create a new project from the routing template.
-3. User can create a new project from the auth-workflow template.
 
-#### React Native (Javascript)
 1. User can create a new project from the blank template.
 2. User can create a new project from the routing template.
 3. User can create a new project from the auth-workflow template.
 
 ### Unit Test Count
+
 9

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/cli",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "A command-line interface for quickly scaffolding Brightlayer UI applications",
     "scripts": {
         "lint": "eslint \"src/**/**.ts\"",

--- a/src/constants/questions.ts
+++ b/src/constants/questions.ts
@@ -18,12 +18,6 @@ export const QUESTIONS = {
         type: 'confirm',
         initial: true,
     },
-    language: {
-        optionName: 'language',
-        question: 'Language',
-        type: 'radio',
-        choices: ['TypeScript', 'JavaScript'],
-    },
     framework: {
         optionName: 'framework',
         question: 'Project Framework:',

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -4,15 +4,7 @@
  */
 import { GluegunToolbox } from 'gluegun';
 import { NPM7_PREFIX, QUESTIONS } from '../constants';
-import {
-    assignJsTs,
-    AngularProps,
-    ReactProps,
-    ReactNativeProps,
-    Template,
-    Language,
-    getVersionString,
-} from '../utilities';
+import { AngularProps, ReactProps, ReactNativeProps, Template, Language, getVersionString } from '../utilities';
 
 module.exports = (toolbox: GluegunToolbox): void => {
     const { system, parse, print } = toolbox;
@@ -40,21 +32,14 @@ module.exports = (toolbox: GluegunToolbox): void => {
 
     const createReactProject = async (): Promise<ReactProps> => {
         let lint = true;
-        let language: Language = 'ts';
+        const language: Language = 'ts';
 
         // Choose a name & template
         const [name, template]: [string, Template] = await parse([QUESTIONS.name, QUESTIONS.template]);
         const isLocal = template.startsWith('file:');
 
-        // Choose a language
-        const [languageTemp]: [string] = await parse([QUESTIONS.language]);
-        language = assignJsTs(languageTemp);
-        const isTs = language === 'ts';
-
         // Choose code formatting options
-        if (isTs) {
-            [lint] = await parse([QUESTIONS.lint]);
-        }
+        [lint] = await parse([QUESTIONS.lint]);
         const [prettier]: [boolean] = await parse([QUESTIONS.prettier]);
 
         // determine the version of the template to use (--alpha, --beta, or explicit --template=name@x.x.x)
@@ -96,6 +81,8 @@ module.exports = (toolbox: GluegunToolbox): void => {
     };
 
     const createReactNativeProject = async (): Promise<ReactNativeProps> => {
+        const language: Language = 'ts';
+
         // Choose a name
         const [name]: [string] = await parse([QUESTIONS.name]);
 
@@ -103,16 +90,9 @@ module.exports = (toolbox: GluegunToolbox): void => {
         let template = '';
         [template] = await parse([QUESTIONS.template]);
 
-        // Choose a language
-        const [languageTemp]: [string] = await parse([QUESTIONS.language]);
-        const language = assignJsTs(languageTemp);
-        const isTs = language === 'ts';
-
         // Choose code formatting options
         let lint = true;
-        if (isTs) {
-            [lint] = await parse([QUESTIONS.lint]);
-        }
+        [lint] = await parse([QUESTIONS.lint]);
         const [prettier] = await parse([QUESTIONS.prettier]);
 
         // Create the basic project

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -96,8 +96,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         const [prettier] = await parse([QUESTIONS.prettier]);
 
         // Create the basic project
-        const command = `${NPM7_PREFIX} && npx react-native init ${name} '--template react-native-template-typescript'
-        }`;
+        const command = `${NPM7_PREFIX} && npx react-native init ${name} '--template react-native-template-typescript'`;
 
         const spinner = print.spin('Creating a new React Native project (this may take a few minutes)...');
         const timer = system.startTimer();

--- a/src/extensions/project-extensions.ts
+++ b/src/extensions/project-extensions.ts
@@ -65,20 +65,20 @@ module.exports = (toolbox: GluegunToolbox): void => {
         switch (templateNameParam.toLocaleLowerCase()) {
             case 'basic routing':
             case 'routing': // to allow for --template=routing instead of --template="basic routing"
-                templateName = isTs ? '@brightlayer-ui/routing-typescript' : '@brightlayer-ui/routing';
+                templateName = '@brightlayer-ui/routing-typescript';
                 break;
             case 'authentication':
-                templateName = isTs ? '@brightlayer-ui/authentication-typescript' : '@brightlayer-ui/authentication';
+                templateName = '@brightlayer-ui/authentication-typescript';
                 break;
             case 'blank':
-                templateName = isTs ? '@brightlayer-ui/blank-typescript' : '@brightlayer-ui/blank';
+                templateName = '@brightlayer-ui/blank-typescript';
                 break;
             default:
                 // allow users to specify a local file to test
                 if (isLocal) {
                     templateName = templateNameParam;
                 } else {
-                    templateName = isTs ? '@brightlayer-ui/blank-typescript' : '@brightlayer-ui/blank';
+                    templateName = '@brightlayer-ui/blank-typescript';
                 }
         }
 
@@ -116,8 +116,7 @@ module.exports = (toolbox: GluegunToolbox): void => {
         const [prettier] = await parse([QUESTIONS.prettier]);
 
         // Create the basic project
-        const command = `${NPM7_PREFIX} && npx react-native init ${name} ${
-            isTs ? '--template react-native-template-typescript' : '--template react-native'
+        const command = `${NPM7_PREFIX} && npx react-native init ${name} '--template react-native-template-typescript'
         }`;
 
         const spinner = print.spin('Creating a new React Native project (this may take a few minutes)...');

--- a/src/extensions/pxblue-extensions.ts
+++ b/src/extensions/pxblue-extensions.ts
@@ -318,27 +318,19 @@ module.exports = (toolbox: GluegunToolbox): void => {
         switch (templateNameParam.toLocaleLowerCase()) {
             case 'basic routing':
             case 'routing':
-                templatePackage = ts
-                    ? '@brightlayer-ui/react-native-template-routing-typescript'
-                    : '@brightlayer-ui/react-native-template-routing';
+                templatePackage = '@brightlayer-ui/react-native-template-routing-typescript';
                 break;
             case 'authentication':
-                templatePackage = ts
-                    ? '@brightlayer-ui/react-native-template-authentication-typescript'
-                    : '@brightlayer-ui/react-native-template-authentication';
+                templatePackage = '@brightlayer-ui/react-native-template-authentication-typescript';
                 break;
             case 'blank':
-                templatePackage = ts
-                    ? '@brightlayer-ui/react-native-template-blank-typescript'
-                    : '@brightlayer-ui/react-native-template-blank';
+                templatePackage = '@brightlayer-ui/react-native-template-blank-typescript';
                 break;
             default:
                 // allow users to specify a local file to test
                 templatePackage = isLocal
                     ? templateNameParam
-                    : ts
-                    ? '@brightlayer-ui/react-native-template-blank-typescript'
-                    : '@brightlayer-ui/react-native-template-blank';
+                    : '@brightlayer-ui/react-native-template-blank-typescript';
         }
 
         // Clone the template repo (if applicable)

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -1,5 +1,5 @@
 import { SUPPORTED_BROWSERS } from '../constants';
-import { PackageJSON, Script, Language } from './types';
+import { PackageJSON, Script } from './types';
 export * from './types';
 
 export const updateScripts = (packageFile: PackageJSON, scripts: Script[] = []): PackageJSON => {
@@ -21,18 +21,6 @@ export const updateBrowsersListJson = (browsersJSON: any): any => {
 
 // convert the string to lower case, and remove all the spaces and dashes.
 export const stringToLowerCaseNoSpace = (str: string): string => str.toLowerCase().replace(/[- ]/gi, '');
-
-export const assignJsTs = (str: string): Language => {
-    switch (stringToLowerCaseNoSpace(str)) {
-        case 'ts':
-        case 'typescript':
-            return 'ts';
-        case 'js':
-        case 'javascript':
-        default:
-            return 'js';
-    }
-};
 
 export const getVersionString = (params: { [key: string]: any }, template: string): [string, string] => {
     const templateArray = template.split('@');

--- a/src/utilities/types.ts
+++ b/src/utilities/types.ts
@@ -1,4 +1,4 @@
-export type Language = 'ts' | 'js';
+export type Language = 'ts';
 
 export type Template = 'Blank' | 'Basic Routing' | 'Authentication';
 


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes # BLUI-3642

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->
#### Changes proposed in this Pull Request:
- Removed references of JS template React and RN from blui cli
- Removed question to select language (JS/TS) , it should by default use TS

<!-- Include screenshots if they will help illustrate the changes in this PR -->
#### Screenshots:
<img width="462" alt="Screenshot 2022-12-14 at 4 25 35 PM" src="https://user-images.githubusercontent.com/25982779/207576907-ef91aa4e-c54c-4127-bed4-f6aea93298b2.png">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->
#### To Test:
- start a local blui-cli project
- Follow the instructions to use local blui-cli
- yarn build
- yarn link
- blui new
- Select React or React Native as framework
- It should not as The language selecetion question
- new cli project should start with TS only
